### PR TITLE
Fix Publish button doesn't get disabled when login fails

### DIFF
--- a/src/CloudFoundry.VisualStudio/Forms/EditDialog.xaml
+++ b/src/CloudFoundry.VisualStudio/Forms/EditDialog.xaml
@@ -170,12 +170,12 @@
 				<Label Content="Configuration" Grid.Row="1" Margin="1.5,2.5,3.5,2.5" Grid.Column="0"/>
 
 				<ComboBox x:Name="Configurations" Margin="0,4" Grid.Row="1" IsEditable="True"
-					Text="{Binding CFMSBuildConfiguration}" Grid.Column="1"/>
+					Text="{Binding CFMSBuildConfiguration}" Grid.Column="1" IsEnabled="False"/>
 
 				<Label Content="Platform" Margin="1.5,2.5,3.5,2.5" Grid.Row="2" Grid.Column="0"/>
              
 				<ComboBox x:Name="Platforms" Margin="0,4.5" Grid.Row="2" IsEditable="True"
-					Text="{Binding CFMSBuildPlatform}" Grid.Column="1" VerticalAlignment="Center"/>
+					Text="{Binding CFMSBuildPlatform}" Grid.Column="1" VerticalAlignment="Center" IsEnabled="False"/>
 			</Grid>
 		</GroupBox>
 		<Grid Grid.Row="5" Grid.ColumnSpan="2" Margin="0,6.001,0,-26.001">
@@ -200,7 +200,7 @@
 			<Button Content="Publish" x:Name="Publish" Grid.Column="4" Width="100" 
 				Click="Publish_Click" Margin="5,2,2.5,6"/>
 			<Button Content="Cancel" x:Name="Cancel" Grid.Column="5" Width="100"
-				Click="Cancel_Click"  Margin="2.5,2,10,6" IsCancel="True"/>
+				Click="Cancel_Click"  Margin="2.5,2,10,6" />
 		</Grid>
 
 	</Grid>

--- a/src/CloudFoundry.VisualStudio/Forms/EditDialog.xaml.cs
+++ b/src/CloudFoundry.VisualStudio/Forms/EditDialog.xaml.cs
@@ -119,6 +119,7 @@ namespace CloudFoundry.VisualStudio
             {
                 StatusIcon.Source = GetBitmapImageFromResources("warning");
                 StatusIcon.ToolTip = "Please set a target";
+                this.Publish.IsEnabled = false;
                 this.IsEnabled = true;
             }
         }
@@ -422,11 +423,19 @@ namespace CloudFoundry.VisualStudio
                 StatusIcon.ToolTip = message;
             });
         }
+        private void DisablePublishButton()
+        {
+            Dispatcher.Invoke(() =>
+            {
+                this.Publish.IsEnabled = false;
+            });
+        }
 
         private async Task InitClient(AppPackage package)
         {
             string imageType = string.Empty;
             string message = string.Empty;
+            this.Publish.IsEnabled = true;
 
             if (package != null)
             {
@@ -446,6 +455,7 @@ namespace CloudFoundry.VisualStudio
                         message = string.Format(CultureInfo.InvariantCulture, "Could not login using the token in your profile. {0}", ex.Message);
                         Logger.Warning(message);
                         SetStatusInfo(imageType, message);
+                        DisablePublishButton();
                         throw ex;
                     }
                 }
@@ -456,6 +466,7 @@ namespace CloudFoundry.VisualStudio
                         imageType = "warning";
                         message = "Please configure credentials for your target.";
                         SetStatusInfo(imageType, message);
+                        DisablePublishButton();
                         return;
                     }
                     if (package.CFPassword == string.Empty)
@@ -468,6 +479,7 @@ namespace CloudFoundry.VisualStudio
                                 imageType = "warning";
                                 message = "Please configure credentials for your target.";
                                 SetStatusInfo(imageType, message);
+                                DisablePublishButton();
                                 return;
                             }
                             CloudCredentials creds = new CloudCredentials();
@@ -482,6 +494,7 @@ namespace CloudFoundry.VisualStudio
                                 imageType = "error";
                                 message = ex.Message;
                                 SetStatusInfo(imageType, message);
+                                DisablePublishButton();
                                 throw ex;
                             }
 
@@ -494,6 +507,7 @@ namespace CloudFoundry.VisualStudio
                             imageType = "warning";
                             message = "Please configure credentials for your target.";
                             SetStatusInfo(imageType, message);
+                            DisablePublishButton();
                             return;
                         }
                     }
@@ -511,6 +525,7 @@ namespace CloudFoundry.VisualStudio
                             imageType = "error";
                             message = string.Format(CultureInfo.InvariantCulture, "{0}. Your password is saved in clear text in the profile!", ex.Message);
                             SetStatusInfo(imageType, message);
+                            DisablePublishButton();
                             throw ex;
                         }
                         imageType = "warning";


### PR DESCRIPTION
Fix: Publish button doesn't get disabled when login fails 
Configuration and Platform default state disabled 
When press Cancel on save configurations, No button closes the screen
